### PR TITLE
Added support for cleaning of additional drives when checking drives …

### DIFF
--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/InitializerActions/CacheCleanerAction.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/InitializerActions/CacheCleanerAction.cs
@@ -1,0 +1,49 @@
+﻿using Sels.Core.Components.Logging;
+using Sels.Core.Extensions;
+using Sels.Crypto.Chia.PlotBot.Contracts;
+using Sels.Crypto.Chia.PlotBot.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Sels.Crypto.Chia.PlotBot.Components.InitializerActions
+{
+    /// <summary>
+    /// Deletes all files in the cache directories of the plotters.
+    /// </summary>
+    public class CacheCleanerAction : IPlotBotInitializerAction
+    {
+        public void Handle(Plotter[] plotters, Drive[] drives)
+        {
+            using (LoggingServices.TraceMethod(this))
+            {
+                if (plotters.HasValue())
+                {
+                    LoggingServices.Log($"Cleaning up caches for {plotters.Length} plotters");
+
+                    foreach(var plotter in plotters)
+                    {
+                        LoggingServices.Debug($"Cleaning caches for {plotter.Alias}");
+
+                        foreach(var cache in plotter.Caches)
+                        {
+                            LoggingServices.Debug($"Searching for files in cache <{cache.Directory.Source.FullName}>");
+
+                            var files = cache.Directory.Source.GetFiles("*", SearchOption.AllDirectories).ToArray();
+
+                            foreach (var file in files)
+                            {
+                                LoggingServices.Trace($"Deleting file <{file.FullName}>");
+                                file.Delete();
+                            }
+
+                            LoggingServices.Log($"Deleted {files.Length} files in cache <{cache.Directory.Source.FullName}>");
+                        }                        
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/InitializerActions/TempFileCleanerAction.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/InitializerActions/TempFileCleanerAction.cs
@@ -1,0 +1,73 @@
+﻿using Sels.Core.Components.Logging;
+using Sels.Core.Extensions;
+using Sels.Crypto.Chia.PlotBot.Contracts;
+using Sels.Crypto.Chia.PlotBot.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Sels.Crypto.Chia.PlotBot.Components.InitializerActions
+{
+    public class TempFileCleanerAction : IPlotBotInitializerAction
+    {
+        public void Handle(Plotter[] plotters, Drive[] drives)
+        {
+            using (LoggingServices.TraceMethod(this))
+            {
+                if (plotters.HasValue() && drives.HasValue())
+                {
+                    LoggingServices.Log($"Checking for plots that failed to copy for {plotters.Length} plotters and {drives.Length} drives");
+
+                    foreach (var plotter in plotters)
+                    {
+                        var copyExtension = plotter.PlotProgressParser.TransferExtension;
+
+                        if (copyExtension.HasValue())
+                        {
+                            LoggingServices.Debug($"Searching for files with extension <{copyExtension}>");
+
+                            foreach (var drive in drives)
+                            {
+                                LoggingServices.Debug($"Checking drive {drive.Alias} with the settings from plotter {plotter.Alias}");
+
+                                var files = drive.Directory.Source.GetFiles($"*{copyExtension}", SearchOption.AllDirectories).ToArray();
+
+
+                                if (files.HasValue())
+                                {
+                                    int deletedFileCount = 0;
+
+                                    foreach (var file in files)
+                                    {
+                                        if ((DateTime.Now - file.LastWriteTime).TotalMinutes > TimeSpan.FromMinutes(1).TotalMinutes)
+                                        {
+                                            LoggingServices.Trace($"Deleting incomplete plot file <{file.FullName}>");
+                                            file.Delete();
+                                            deletedFileCount++;
+                                        }
+                                        else
+                                        {
+                                            LoggingServices.Trace($"File <{file.FullName}> was modified less than 1 minute ago so not deleting");
+                                        }
+                                    }
+
+                                    LoggingServices.Log($"Deleted {deletedFileCount} failed plot files from the total {files.Length} files found");
+                                }
+                                else
+                                {
+                                    LoggingServices.Log($"No failed plots found in drive {drive.Alias} with the settings from plotter {plotter.Alias}");
+                                }
+                            }
+                        }
+                        else
+                        {
+                            LoggingServices.Warning($"Could not get copy extension from plotter {plotter.Alias}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/PlotProgressParsers/RegexPlotProgressParser.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/PlotProgressParsers/RegexPlotProgressParser.cs
@@ -25,13 +25,6 @@ namespace Sels.Crypto.Chia.PlotBot.Components.PlotProgressParsers
             instance.ValidateArgument(nameof(instance));
             plotFileName = string.Empty;
 
-            // Wait for file to be able to be read
-            while (instance.ProgressFile.IsLocked())
-            {
-                Thread.Sleep(250);
-                LoggingServices.Debug($"Progress file {instance.ProgressFile.FullName} is locked. Waiting for it to unlock");
-            }
-
             var progressFileContent = instance.ProgressFile.Read();
 
             // Check file content for words matching the regex filter

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/PlotProgressParsers/StringPlotProgressParser.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/PlotProgressParsers/StringPlotProgressParser.cs
@@ -24,13 +24,6 @@ namespace Sels.Crypto.Chia.PlotBot.Components.PlotProgressParsers
             instance.ValidateArgument(nameof(instance));
             plotFileName = string.Empty;
 
-            // Wait for file to be able to be read
-            while (instance.ProgressFile.IsLocked())
-            {
-                Thread.Sleep(250);
-                LoggingServices.Debug($"Progress file {instance.ProgressFile.FullName} is locked. Waiting for it to unlock");
-            }
-
             var progressFileContent = instance.ProgressFile.Read();
 
             // Check file content for words matching the regex filter

--- a/Chia/Sels.Crypto.Chia.PlotBot/Contracts/IPlotBotInitializerAction.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Contracts/IPlotBotInitializerAction.cs
@@ -1,0 +1,20 @@
+﻿using Sels.Crypto.Chia.PlotBot.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sels.Crypto.Chia.PlotBot.Contracts
+{
+    /// <summary>
+    /// Allows for the execution of an action with the plotters and drives after plotbot initialized for the first time.
+    /// </summary>
+    public interface IPlotBotInitializerAction
+    {
+        /// <summary>
+        /// Performs an action with <paramref name="plotters"/> or <paramref name="drives"/> after plot bot has initialized.
+        /// </summary>
+        /// <param name="plotters">Plotter that plot bot loading in</param>
+        /// <param name="drives">Drives that plot bot loaded in</param>
+        void Handle(Plotter[] plotters, Drive[] drives);
+    }
+}

--- a/Chia/Sels.Crypto.Chia.PlotBot/Models/Drive.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Models/Drive.cs
@@ -92,14 +92,22 @@ namespace Sels.Crypto.Chia.PlotBot.Models
 
             LoggingServices.Trace($"Drive {Alias} has {freeSize.ToSize(PlotBotConstants.Logging.DefaultLoggingFileSize)} of free space");
 
-            if (!enoughSpace && DriveClearers.HasValue())
+            try
             {
-                LoggingServices.Debug($"Drive {Alias} does not enough free disk space for {size.ToSize(PlotBotConstants.Logging.DefaultLoggingFileSize)}. Trying to clear disk space with drive clearers");
-                if(DriveClearers.Any(x => x.ClearSpace(this, size)))
+                if (!enoughSpace && DriveClearers.HasValue())
                 {
-                    LoggingServices.Log($"Drive {Alias} has cleared extra space");
-                    return true;
+                    LoggingServices.Debug($"Drive {Alias} does not enough free disk space for {size.ToSize(PlotBotConstants.Logging.DefaultLoggingFileSize)}. Trying to clear disk space with drive clearers");
+                    if (DriveClearers.Any(x => x.ClearSpace(this, size)))
+                    {
+                        LoggingServices.Log($"Drive {Alias} has cleared extra space");
+                        return true;
+                    }
                 }
+            }
+            catch(Exception ex)
+            {
+                LoggingServices.Log(LogLevel.Warning, $"Drive {Alias} ran into issues when trying to clear disk space", ex);
+                enoughSpace = AvailableFreeSize > size;
             }
 
             if (!enoughSpace)
@@ -115,7 +123,7 @@ namespace Sels.Crypto.Chia.PlotBot.Models
             using var logger = LoggingServices.TraceMethod(this);
             plottingInstance.ValidateArgument(nameof(plottingInstance));
 
-            LoggingServices.Debug($"Adding instance {plottingInstance} to Drive {Alias}");
+            LoggingServices.Debug($"Adding instance {plottingInstance.Name} to Drive {Alias}");
 
             _plottingInstances.Add(plottingInstance);
         }
@@ -125,7 +133,7 @@ namespace Sels.Crypto.Chia.PlotBot.Models
             using var logger = LoggingServices.TraceMethod(this);
             plottingInstance.ValidateArgument(nameof(plottingInstance));
 
-            LoggingServices.Debug($"Removing instance {plottingInstance} from Drive {Alias}");
+            LoggingServices.Debug($"Removing instance {plottingInstance.Name} from Drive {Alias}");
 
             _plottingInstances.Remove(plottingInstance);
         }

--- a/Chia/Sels.Crypto.Chia.PlotBot/Models/Plotter.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Models/Plotter.cs
@@ -197,7 +197,7 @@ namespace Sels.Crypto.Chia.PlotBot.Models
                 followNumber++;
             }
 
-            LoggingServices.Log($"New plotting instance will use {threads} Threads, {ram}MB Ram, {Buckets} buckets to create {PlotSize.Name} plots of size {PlotSize.FinalSize} using a cache size of {PlotSize.CreationSize} for destination drive {drive.Alias}");
+            LoggingServices.Log($"New plotting instance will use {threads} Threads, {ram}MB Ram, {Buckets} buckets to create {PlotAmount} plots of size {PlotSize.FinalSize} ({PlotSize.Name}) using a cache size of {PlotSize.CreationSize} for destination drive {drive.Alias}");
 
             LoggingServices.Debug($"{Alias} preparing parameters to plot to {drive.Alias}");
             // Prepare parameters
@@ -257,7 +257,7 @@ namespace Sels.Crypto.Chia.PlotBot.Models
             using var logger = LoggingServices.TraceMethod(this);
             plottingInstance.ValidateArgument(nameof(plottingInstance));
 
-            LoggingServices.Debug($"Adding instance {plottingInstance} to Plotter {Alias}");
+            LoggingServices.Debug($"Adding instance {plottingInstance.Name} to Plotter {Alias}");
 
             _plottingInstances.Add(plottingInstance);
         }
@@ -267,7 +267,7 @@ namespace Sels.Crypto.Chia.PlotBot.Models
             using var logger = LoggingServices.TraceMethod(this);
             plottingInstance.ValidateArgument(nameof(plottingInstance));
 
-            LoggingServices.Debug($"Removing instance {plottingInstance} from Plotter {Alias}");
+            LoggingServices.Debug($"Removing instance {plottingInstance.Name} from Plotter {Alias}");
 
             _plottingInstances.Remove(plottingInstance);
         }

--- a/Chia/Sels.Crypto.Chia.PlotBot/Models/PlottingInstance.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Models/PlottingInstance.cs
@@ -127,7 +127,7 @@ namespace Sels.Crypto.Chia.PlotBot.Models
 
                 while (IsPlotting)
                 {
-                    LoggingServices.Debug($"Cancelled Instance {Name} waiting for task to finish");
+                    LoggingServices.Trace($"Cancelled Instance {Name} waiting for task to finish");
                     Thread.Sleep(250);
                 }
             }           

--- a/Chia/Sels.Crypto.Chia.PlotBot/PlotBotConstants.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/PlotBotConstants.cs
@@ -48,6 +48,9 @@ namespace Sels.Crypto.Chia.PlotBot
                 public const string TestMode = "Service.TestMode";
                 public const string ConfigFile = "Service.ConfigFile";
                 public const string Interval = "Service.Interval";
+
+                public const string CleanupCache = "Service.PlotBot.CleanupCache";
+                public const string CleanupFailedCopy = "Service.PlotBot.CleanupFailedCopy";
             }
 
             public static class LogSettings

--- a/Chia/Sels.Crypto.Chia.PlotBot/Program.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Program.cs
@@ -37,6 +37,7 @@ using Sels.Core.Components.Logging;
 using Sels.Crypto.Chia.PlotBot.Components.PlotProgressParsers;
 using Sels.Crypto.Chia.PlotBot.Components.Factories;
 using Sels.Crypto.Chia.PlotBot.Components.Services;
+using Sels.Crypto.Chia.PlotBot.Components.InitializerActions;
 
 namespace Sels.Crypto.Chia.PlotBot
 {
@@ -108,6 +109,17 @@ namespace Sels.Crypto.Chia.PlotBot
                     {
                         services.AddHostedService<PlotBotManager>();
                         services.AddSingleton<IPlottingService, LinuxPlottingService>();
+                    }
+
+                    // Setup initializer actions
+                    if (configProvider.GetAppSetting<bool>(PlotBotConstants.Config.AppSettings.CleanupCache, false))
+                    {
+                        services.AddSingleton<IPlotBotInitializerAction, CacheCleanerAction>();
+                    }
+
+                    if(configProvider.GetAppSetting<bool>(PlotBotConstants.Config.AppSettings.CleanupFailedCopy, false))
+                    {
+                        services.AddSingleton<IPlotBotInitializerAction, TempFileCleanerAction>();
                     }
 
                     // Setup service factory

--- a/Chia/Sels.Crypto.Chia.PlotBot/TestPlotBot.json
+++ b/Chia/Sels.Crypto.Chia.PlotBot/TestPlotBot.json
@@ -8,14 +8,15 @@
       {
         "Name": "K32",
         "CreationSize": 220.0,
-        "FinalSize": 101.4
+        "FinalSize": 10100.4
       }
     ],
     "DriveClearers": [
       {
         "Name": "OgDate",
         "Arguments": {
-          "ThresHold": "07/07/2021"
+          "ThresHold": "07/07/2021",
+          "AdditionalDrives": "/mnt/c/; /mnt/g/"
         }
       }
     ]
@@ -50,6 +51,7 @@
       "Progress": {
         "Name": "String",
         "Arguments": {
+          "TransferExtension": ".plot.tmp",
           "Filter": "plot-"
         }
       },

--- a/Chia/Sels.Crypto.Chia.PlotBot/appsettings.json
+++ b/Chia/Sels.Crypto.Chia.PlotBot/appsettings.json
@@ -3,7 +3,9 @@
     "Service.DevMode": true,
     "Service.TestMode": true,
     "Service.ConfigFile": "TestPlotBot.json",
-    "Service.Interval": 1000
+    "Service.Interval": 1000,
+    "Service.PlotBot.CleanupCache": true,
+    "Service.PlotBot.CleanupFailedCopy":  true
   },
   "LogSettings": {
     "MinLevel": "Debug",


### PR DESCRIPTION
…for free space + Added optional cleanup actions for cache directories and plots that failed to copy during startup

- Added AdditionalDrives argument to OgPlotClearer
- Added IPlotBotInitializerAction
- Added  CacheCleanerAction
- Added  TempFileCleanerAction
- PlotParsers no longer wait for progress file to become writeable
- Plot bot no longer stops plotting when a drive clearer fails
- Updated/Fixed some log messages
- Plot Bot can now trigger actions when it is reloading config for the first time