### PR TITLE
Plot Bot 0.2.0

### DIFF
--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/BaseClearer.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/BaseClearer.cs
@@ -1,0 +1,156 @@
+﻿using Sels.Core.Contracts.Factory;
+using Sels.Core.Templates.FileSizes;
+using Sels.Core.Templates.FileSystem;
+using Sels.Crypto.Chia.PlotBot.Contracts;
+using Sels.Crypto.Chia.PlotBot.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Sels.Core.Extensions;
+using System.Linq;
+using Sels.Core.Components.Logging;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Sels.Core.Components.FileSizes.Byte;
+using Sels.Core.Components.FileSizes.Byte.Binary;
+
+namespace Sels.Crypto.Chia.PlotBot.Components.DriveClearers
+{
+    /// <summary>
+    /// Base class with common properties and methods.
+    /// </summary>
+    public abstract class BaseClearer : IDriveSpaceClearer
+    {
+        // Constants
+        private const string DriveSplitter = ";";
+        private const string PlotFilter = "*.plot";
+
+        // Fields
+        protected string _loggerName;
+        private string _additionalDrives;
+        private CrossPlatformDirectory[] _additionalDirectories;
+        private readonly IFactory<CrossPlatformDirectory> _directoryFactory;
+
+        // Properties
+        public string AdditionalDrives
+        {
+            get
+            {
+                return _additionalDrives;
+            }
+            set
+            {
+                _additionalDrives = value;
+                if (_additionalDrives.HasValue())
+                {
+                    _additionalDirectories = _additionalDrives.Split(DriveSplitter, StringSplitOptions.RemoveEmptyEntries).Select(x => _directoryFactory.Create(x.Trim())).ToArray();
+                }
+            }
+        }
+
+        public BaseClearer(IFactory<CrossPlatformDirectory> directoryFactory)
+        {
+            _loggerName = GetType().Name;
+            _directoryFactory = directoryFactory.ValidateArgument(nameof(directoryFactory));
+        }
+
+        public virtual bool ClearSpace(Drive drive, FileSize requiredSize)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            drive.ValidateArgument(nameof(drive));
+            requiredSize.ValidateArgument(nameof(requiredSize));
+
+            var freeSpace = drive.AvailableFreeSize;
+            FileSize deletedSize = new SingleByte(0);
+
+            LoggingServices.Trace($"Drive {drive.Alias} has {freeSpace.ToSize<GibiByte>()} free");
+
+            foreach (var clearableFile in GetClearableFiles(drive, requiredSize))
+            {
+                var fileSize = clearableFile.GetFileSize<GibiByte>();
+
+                HandleClearableFile(drive, requiredSize, clearableFile, fileSize);
+                deletedSize += fileSize;
+
+                if (deletedSize + freeSpace >= requiredSize)
+                {
+                    LoggingServices.Log($"Freed up {deletedSize.ToSize<GibiByte>()} on Drive {drive.Alias}");
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        protected IEnumerable<FileInfo> GetClearableFiles(Drive drive, FileSize requiredSize)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            // Seach drive root first
+            LoggingServices.Debug($"Seaching drive {drive.Alias} for clearable files");
+            var plots = GetClearableFiles(drive, requiredSize, drive.Directory);
+
+            foreach (var plot in plots)
+            {
+                yield return plot;
+            }
+
+            if (AdditionalDrives.HasValue())
+            {
+                var mointPoint = drive.Directory.MountPoint;
+                LoggingServices.Debug($"Seaching additional drives for drive {drive.Alias} that have the same mount point. Moint point is <{mointPoint}>");
+                var matchingDirectories = _additionalDirectories.Where(x => x.Exists && x.MountPoint.Equals(mointPoint)).ToArray();
+
+                if (matchingDirectories.HasValue())
+                {
+                    foreach (var directory in matchingDirectories)
+                    {
+                        LoggingServices.Debug($"Seaching additional drive {directory.FullName} for clearable files");
+
+                        foreach (var plot in GetClearableFiles(drive, requiredSize, directory))
+                        {
+                            yield return plot;
+                        }
+                    }
+                }
+                else
+                {
+                    LoggingServices.Debug($"None of the additional drives share a moint point with drive {drive.Alias}");
+                }
+            }
+        }
+
+        protected IEnumerable<FileInfo> GetClearableFiles(Drive drive, FileSize requiredSize, CrossPlatformDirectory directory)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            var plots = directory.Source.GetFiles(PlotFilter, SearchOption.AllDirectories);
+
+            LoggingServices.Log(LogLevel.Debug, $"{_loggerName} found {plots.Length} plots to check");
+
+            if (plots.HasValue())
+            {
+                foreach (var plot in plots)
+                {
+                    if (IsClearablePlot(drive, requiredSize, plot))
+                    {
+                        yield return plot;
+                    }
+                }
+            }
+        }
+
+        protected virtual void HandleClearableFile(Drive drive, FileSize requiredFreeSpace, FileInfo plot, FileSize plotSize)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+            LoggingServices.Log($"Clearing {plot.FullName} of size {plotSize} on drive {drive.Alias}");
+            plot.Delete();
+        }
+
+        // Abstractions
+        protected abstract bool IsClearablePlot(Drive drive, FileSize requiredFreeSpace, FileInfo plot);
+        public abstract IDriveSpaceClearer Validate();
+    }
+}

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotByteClearer.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotByteClearer.cs
@@ -1,0 +1,111 @@
+﻿using Sels.Core.Components.Logging;
+using Sels.Core.Contracts.Factory;
+using Sels.Core.Templates.FileSizes;
+using Sels.Core.Templates.FileSystem;
+using Sels.Crypto.Chia.PlotBot.Contracts;
+using Sels.Crypto.Chia.PlotBot.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Sels.Core.Extensions.Conversion;
+
+namespace Sels.Crypto.Chia.PlotBot.Components.DriveClearers
+{
+    /// <summary>
+    /// Clears og plots by checking bytes in the plot header.
+    /// </summary>
+    public class OgPlotByteClearer : BaseClearer
+    {
+        // Constants
+        private const int StartByteOffset = 52;
+
+        public OgPlotByteClearer(IFactory<CrossPlatformDirectory> directoryFactory) : base(directoryFactory)
+        {
+
+        }
+
+        public override IDriveSpaceClearer Validate()
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+            return this;
+        }
+
+        protected override bool IsClearablePlot(Drive drive, FileSize requiredFreeSpace, FileInfo plot)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            using(var reader = new BinaryReader(plot.OpenRead()))
+            {
+                const int readLength = 2;          
+                int offset = 0;
+                LoggingServices.Trace($"Opening stream for <{plot.FullName}>");
+
+                // 1000 bytes should give enough headroom
+                byte[] buffer = new byte[readLength];
+
+                // Read format length in plot header to calculate byte location for memo
+                LoggingServices.Trace($"Reading format length from byte stream for <{plot.FullName}>");
+                offset = StartByteOffset;
+                reader.BaseStream.Seek(offset, SeekOrigin.Begin);
+                reader.Read(buffer);
+                var formatLength = GetLength(buffer);
+                LoggingServices.Trace($"Format length for <{plot.FullName}> is <{formatLength}>");
+
+                // Read memo length from plot header
+                LoggingServices.Trace($"Reading memo length from byte stream for <{plot.FullName}>");
+                offset = StartByteOffset + readLength + formatLength;
+                reader.BaseStream.Seek(offset, SeekOrigin.Begin);
+                reader.Read(buffer);
+                var memoLength = GetLength(buffer);
+                LoggingServices.Trace($"Memo length for <{plot.FullName}> is <{formatLength}>");
+
+                // Try convert memo length to plot type
+                var plotType = PlotType.Unknown;
+
+                if(Enum.IsDefined(typeof(PlotType), memoLength))
+                {
+                    plotType = memoLength.As<PlotType>();
+                }
+
+                LoggingServices.Trace($"Plot type for <{plot.FullName}> is <{plotType}>");
+
+                switch (plotType)
+                {
+                    case PlotType.Og:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        private int GetLength(byte[] bytes)
+        {
+            return bytes[1] >> bytes[0];
+        }
+    }
+
+    public class TestOgPlotByteClearer : OgPlotByteClearer
+    {
+        public TestOgPlotByteClearer(IFactory<CrossPlatformDirectory> directoryFactory) : base(directoryFactory)
+        {
+
+        }
+
+        protected override void HandleClearableFile(Drive drive, FileSize requiredFreeSpace, FileInfo plot, FileSize plotSize)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            LoggingServices.Log($"Test Mode: {plot.FullName} of size {plotSize} on drive {drive.Alias} would have been cleared to make enough space for {requiredFreeSpace}");
+        }
+    }
+
+    internal enum PlotType
+    {
+        Unknown = 0,
+        Og = 128,
+        Nft = 112
+    }
+}

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotByteClearer.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotByteClearer.cs
@@ -32,7 +32,7 @@ namespace Sels.Crypto.Chia.PlotBot.Components.DriveClearers
             return this;
         }
 
-        protected override bool IsClearablePlot(Drive drive, FileSize requiredFreeSpace, FileInfo plot)
+        protected override bool IsClearableFile(Drive drive, FileSize requiredFreeSpace, FileInfo plot)
         {
             using var logger = LoggingServices.TraceMethod(this);
 

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotDateClearer.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotDateClearer.cs
@@ -42,7 +42,7 @@ namespace Sels.Crypto.Chia.PlotBot.Components.DriveClearers
             return this;
         }
 
-        protected override bool IsClearablePlot(Drive drive, FileSize requiredFreeSpace, FileInfo plot)
+        protected override bool IsClearableFile(Drive drive, FileSize requiredFreeSpace, FileInfo plot)
         {
             using var logger = LoggingServices.TraceMethod(this);
 

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotDateClearer.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/OgPlotDateClearer.cs
@@ -18,158 +18,56 @@ using System.Text;
 namespace Sels.Crypto.Chia.PlotBot.Components.DriveClearers
 {
     /// <summary>
-    /// Clears old plots by checking the the date in the file name.
+    /// Clears og plots by checking the date in the file name.
     /// </summary>
-    public class OgPlotDateClearer : IDriveSpaceClearer
+    public class OgPlotDateClearer : BaseClearer
     {
         // Constants
-        private const string Name = "Og Plot Date Clearer";
-        private const string PlotFilter = "*.plot";
         private const int StartIndex = 9;
         private const int DateLength = 16;
         private const string DateTimeFormat = "yyyy-MM-dd-HH-mm";
-        private const string DriveSplitter = ";";
-
-        // Fields
-        private string _additionalDrives;
-        private CrossPlatformDirectory[] _additionalDirectories;
-        private readonly IFactory<CrossPlatformDirectory> _directoryFactory;
-
-        // Properties
-        public string AdditionalDrives { 
-            get 
-            { 
-                return _additionalDrives; 
-            } 
-            set 
-            {
-                _additionalDrives = value;
-                if (_additionalDrives.HasValue())
-                {
-                    _additionalDirectories = _additionalDrives.Split(DriveSplitter, StringSplitOptions.RemoveEmptyEntries).Select(x => _directoryFactory.Create(x.Trim())).ToArray();
-                }
-            } 
-        }
 
         /// <summary>
         /// Plots older than this date can be deleted.
         /// </summary>
         public DateTime ThresHold { get; set; }
 
-        public OgPlotDateClearer(IFactory<CrossPlatformDirectory> directoryFactory)
+        public OgPlotDateClearer(IFactory<CrossPlatformDirectory> directoryFactory) : base(directoryFactory)
         {
-            _directoryFactory = directoryFactory.ValidateArgument(nameof(directoryFactory));
         }
-
-        public virtual bool ClearSpace(Drive drive, FileSize requiredSize)
-        {
-            using var logger = LoggingServices.TraceMethod(this);
-
-            drive.ValidateArgument(nameof(drive));
-            requiredSize.ValidateArgument(nameof(requiredSize));
-
-            var freeSpace = drive.AvailableFreeSize;
-            FileSize deletedSize = new SingleByte(0);
-
-            LoggingServices.Trace($"Drive {drive.Alias} has {freeSpace.ToSize<GibiByte>()} free");
-
-            foreach(var clearableFile in GetClearableFiles(drive))
-            {
-                var fileSize = clearableFile.GetFileSize<GibiByte>();
-                LoggingServices.Log($"Clearing {clearableFile.FullName} of size {fileSize} on drive {drive.Alias}");
-
-                clearableFile.Delete();
-                deletedSize += fileSize;
-
-                if(deletedSize+freeSpace >= requiredSize)
-                {
-                    LoggingServices.Log($"Freed up {deletedSize.ToSize<GibiByte>()} on Drive {drive.Alias}");
-
-                    return true;
-                }
-            }
-           
-            return false;
-        }
-
-        public IEnumerable<FileInfo> GetClearableFiles(Drive drive)
-        {
-            using var logger = LoggingServices.TraceMethod(this);
-
-            // Seach drive root first
-            LoggingServices.Debug($"Seaching drive {drive.Alias} for clearable files");
-            var plots = GetClearableFiles(drive.Directory);
-
-            foreach(var plot in plots)
-            {
-                yield return plot;
-            }
-
-            if (_additionalDirectories.HasValue())
-            {
-                var mointPoint = drive.Directory.MountPoint;
-                LoggingServices.Debug($"Seaching additional drives for drive {drive.Alias} that have the same mount point. Moint point is <{mointPoint}>");
-                var matchingDirectories = _additionalDirectories.Where(x => x.Exists && x.MountPoint.Equals(mointPoint)).ToArray();
-
-                if (matchingDirectories.HasValue())
-                {
-                    foreach(var directory in matchingDirectories)
-                    {
-                        LoggingServices.Debug($"Seaching additional drive {directory.FullName} for clearable files");
-
-                        foreach(var plot in GetClearableFiles(directory))
-                        {
-                            yield return plot;
-                        }
-                    }
-                }
-                else
-                {
-                    LoggingServices.Debug($"None of the additional drives share a moint point with drive {drive.Alias}");
-                }
-            }
-        }
-
-        public IEnumerable<FileInfo> GetClearableFiles(CrossPlatformDirectory directory)
-        {
-            using var logger = LoggingServices.TraceMethod(this);
-
-            var plots = directory.Source.GetFiles(PlotFilter, SearchOption.AllDirectories);
-
-            LoggingServices.Log(LogLevel.Debug, $"{Name} found {plots.Length} plots to check");
-
-            if (plots.HasValue())
-            {
-                foreach (var plot in plots)
-                {
-                    var datePart = plot.Name.Substring(StartIndex, DateLength);
-
-                    LoggingServices.Trace($"Extracted date section {datePart} from plot {plot.FullName}");
-
-                    if (DateTime.TryParseExact(datePart, DateTimeFormat, null, DateTimeStyles.None, out var date))
-                    {
-                        if (date < ThresHold)
-                        {
-                            LoggingServices.Trace($"Plot {plot.FullName} was created on {date} and passed the threshold date of {ThresHold}");
-                            yield return plot;
-                        }
-                        else
-                        {
-                            LoggingServices.Trace($"Plot {plot.FullName} was created on {date} and did not pass the threshold date of {ThresHold}");
-                        }
-                    }
-                    else
-                    {
-                        LoggingServices.Warning($"Could not convert date section from Plot {plot.FullName}");
-                    }
-                }
-            }
-        }
-
-        public IDriveSpaceClearer Validate()
+      
+        public override IDriveSpaceClearer Validate()
         {
             using var logger = LoggingServices.TraceMethod(this);
             return this;
+        }
+
+        protected override bool IsClearablePlot(Drive drive, FileSize requiredFreeSpace, FileInfo plot)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            var datePart = plot.Name.Substring(StartIndex, DateLength);
+
+            LoggingServices.Trace($"Extracted date section {datePart} from plot {plot.FullName}");
+
+            if (DateTime.TryParseExact(datePart, DateTimeFormat, null, DateTimeStyles.None, out var date))
+            {
+                if (date < ThresHold)
+                {
+                    LoggingServices.Trace($"Plot {plot.FullName} was created on {date} and passed the threshold date of {ThresHold}");
+                    return true;
+                }
+                else
+                {
+                    LoggingServices.Trace($"Plot {plot.FullName} was created on {date} and did not pass the threshold date of {ThresHold}");
+                }
+            }
+            else
+            {
+                LoggingServices.Warning($"Could not convert date section from Plot {plot.FullName}");
+            }
+
+            return false;
         }
     }
 
@@ -180,35 +78,11 @@ namespace Sels.Crypto.Chia.PlotBot.Components.DriveClearers
 
         }
 
-        public override bool ClearSpace(Drive drive, FileSize requiredSize)
+        protected override void HandleClearableFile(Drive drive, FileSize requiredFreeSpace, FileInfo plot, FileSize plotSize)
         {
             using var logger = LoggingServices.TraceMethod(this);
 
-            drive.ValidateArgument(nameof(drive));
-            requiredSize.ValidateArgument(nameof(requiredSize));
-
-            var freeSpace = drive.AvailableFreeSize;
-            FileSize deletedSize = new SingleByte(0);
-
-            LoggingServices.Trace($"Drive {drive.Alias} has {freeSpace.ToSize<GibiByte>()} free");
-
-            foreach (var clearableFile in GetClearableFiles(drive))
-            {
-                var fileSize = clearableFile.GetFileSize<GibiByte>();
-
-                LoggingServices.Log($"Test Mode: {clearableFile.FullName} of size {fileSize} on drive {drive.Alias} would have been cleared to make enough space for {requiredSize}");
-
-                deletedSize += fileSize;
-
-                if (deletedSize + freeSpace >= requiredSize)
-                {
-                    LoggingServices.Log($"Test Mode: Would have freed up {deletedSize.ToSize<GibiByte>()} on Drive {drive.Alias}");
-
-                    return true;
-                }
-            }
-
-            return false;
+            LoggingServices.Log($"Test Mode: {plot.FullName} of size {plotSize} on drive {drive.Alias} would have been cleared to make enough space for {requiredFreeSpace}");
         }
     }
 }

--- a/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/ZeroByteClearer.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Components/DriveClearers/ZeroByteClearer.cs
@@ -1,0 +1,58 @@
+﻿using Sels.Core.Components.FileSizes.Byte;
+using Sels.Core.Components.Logging;
+using Sels.Core.Contracts.Factory;
+using Sels.Core.Templates.FileSizes;
+using Sels.Core.Templates.FileSystem;
+using Sels.Crypto.Chia.PlotBot.Contracts;
+using Sels.Crypto.Chia.PlotBot.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Sels.Crypto.Chia.PlotBot.Components.DriveClearers
+{
+    /// <summary>
+    /// Drive clearer that deletes 0 byte files. 
+    /// </summary>
+    public class ZeroByteClearer : BaseClearer
+    {
+        public ZeroByteClearer(IFactory<CrossPlatformDirectory> directoryFactory) : base(directoryFactory)
+        {
+
+        }
+
+        public override IDriveSpaceClearer Validate()
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+            return this;
+        }
+
+        protected override bool IsClearableFile(Drive drive, FileSize requiredFreeSpace, FileInfo file)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            var isZeroByte = file.GetFileSize<SingleByte>() == 0;
+
+            LoggingServices.Trace($"Found zero byte plot <{file.FullName}>");
+
+            // Only clear if they haven't been modified in 5 minutes to avoid files that were just created.
+            return isZeroByte && file.LastWriteTime < DateTime.Now.AddMinutes(-5);
+        }
+    }
+
+    public class TestZeroByteClearer : ZeroByteClearer
+    {
+        public TestZeroByteClearer(IFactory<CrossPlatformDirectory> directoryFactory) : base(directoryFactory)
+        {
+
+        }
+
+        protected override void HandleClearableFile(Drive drive, FileSize requiredFreeSpace, FileInfo plot, FileSize plotSize)
+        {
+            using var logger = LoggingServices.TraceMethod(this);
+
+            LoggingServices.Log($"Test Mode: {plot.FullName} of size {plotSize} on drive {drive.Alias} would have been cleared to make enough space for {requiredFreeSpace}");
+        }
+    }
+}

--- a/Chia/Sels.Crypto.Chia.PlotBot/Models/Drive.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Models/Drive.cs
@@ -73,10 +73,10 @@ namespace Sels.Crypto.Chia.PlotBot.Models
         }
 
         /// <summary>
-        /// Checks if this drive be plotted to. Tries to free up extra space until we have enough free space for <paramref name="size"/>
+        /// Checks if this drive be plotted to. Tries to free up extra disk space until we have enough free disk space for <paramref name="size"/>
         /// </summary>
-        /// <param name="size">Needed free space</param>
-        /// <returns>True if enough free space is available</returns>
+        /// <param name="size">Needed free disk space</param>
+        /// <returns>True if enough free disk space is available</returns>
         public bool CanBePlotted(FileSize size)
         {
             using var logger = LoggingServices.TraceMethod(this);
@@ -112,7 +112,7 @@ namespace Sels.Crypto.Chia.PlotBot.Models
 
             if (!enoughSpace)
             {
-                LoggingServices.Log(LogLevel.Debug, $"Drive {Alias} does not have enough free size available. Needs {size.ToSize(PlotBotConstants.Logging.DefaultLoggingFileSize)} but only has {AvailableFreeSize.ToSize(PlotBotConstants.Logging.DefaultLoggingFileSize)}");
+                LoggingServices.Log(LogLevel.Debug, $"Drive {Alias} does not have enough free disk space available. Needs {size.ToSize(PlotBotConstants.Logging.DefaultLoggingFileSize)} but only has {AvailableFreeSize.ToSize(PlotBotConstants.Logging.DefaultLoggingFileSize)}");
             }
 
             return enoughSpace;

--- a/Chia/Sels.Crypto.Chia.PlotBot/PlotBotConstants.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/PlotBotConstants.cs
@@ -127,6 +127,7 @@ namespace Sels.Crypto.Chia.PlotBot
                 public const string OgDateThreshold = "Threshold";
                 public const string OgDateThresholdArg = "07/07/2021";
 
+                public const string OgByte = "OgByte";
             }
 
             public static class Delay

--- a/Chia/Sels.Crypto.Chia.PlotBot/PlotBotConstants.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/PlotBotConstants.cs
@@ -128,6 +128,8 @@ namespace Sels.Crypto.Chia.PlotBot
                 public const string OgDateThresholdArg = "07/07/2021";
 
                 public const string OgByte = "OgByte";
+
+                public const string ZeroByte = "ZeroByte";
             }
 
             public static class Delay

--- a/Chia/Sels.Crypto.Chia.PlotBot/Program.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Program.cs
@@ -157,11 +157,13 @@ namespace Sels.Crypto.Chia.PlotBot
                         {
                             factory.Register<IDriveSpaceClearer, TestOgPlotDateClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgDate);
                             factory.Register<IDriveSpaceClearer, TestOgPlotByteClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgByte);
+                            factory.Register<IDriveSpaceClearer, TestZeroByteClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.ZeroByte);
                         }
                         else
                         {
                             factory.Register<IDriveSpaceClearer, OgPlotDateClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgDate);
                             factory.Register<IDriveSpaceClearer, OgPlotByteClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgByte);
+                            factory.Register<IDriveSpaceClearer, ZeroByteClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.ZeroByte);
                         }
 
                         return factory;

--- a/Chia/Sels.Crypto.Chia.PlotBot/Program.cs
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Program.cs
@@ -156,10 +156,12 @@ namespace Sels.Crypto.Chia.PlotBot
                         if (testMode)
                         {
                             factory.Register<IDriveSpaceClearer, TestOgPlotDateClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgDate);
+                            factory.Register<IDriveSpaceClearer, TestOgPlotByteClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgByte);
                         }
                         else
                         {
                             factory.Register<IDriveSpaceClearer, OgPlotDateClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgDate);
+                            factory.Register<IDriveSpaceClearer, OgPlotByteClearer>(ServiceScope.Transient, PlotBotConstants.Components.Clearer.OgByte);
                         }
 
                         return factory;

--- a/Chia/Sels.Crypto.Chia.PlotBot/Sels.Crypto.Chia.PlotBot.csproj
+++ b/Chia/Sels.Crypto.Chia.PlotBot/Sels.Crypto.Chia.PlotBot.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>dotnet-Sels.Crypto.Chia.PlotBot-AE9C3215-1CA9-41A6-BA0E-5EB24098DF8A</UserSecretsId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Jens Sels</Authors>
     <Company>Homebrew IT</Company>
     <Product>Chia Plot Bot</Product>

--- a/Chia/Sels.Crypto.Chia.PlotBot/TestPlotBot.json
+++ b/Chia/Sels.Crypto.Chia.PlotBot/TestPlotBot.json
@@ -8,10 +8,16 @@
       {
         "Name": "K32",
         "CreationSize": 220.0,
-        "FinalSize": 101.4
+        "FinalSize": 10100.4
       }
     ],
     "DriveClearers": [
+      {
+        "Name": "OgByte",
+        "Arguments": {
+          "AdditionalDrives": "/mnt/c/; /mnt/g/"
+        }
+      },
       {
         "Name": "OgDate",
         "Arguments": {

--- a/Chia/Sels.Crypto.Chia.PlotBot/appsettings.Debug.json
+++ b/Chia/Sels.Crypto.Chia.PlotBot/appsettings.Debug.json
@@ -2,7 +2,7 @@
   "AppSettings": {
     "Service.DevMode": true,
     "Service.TestMode": true,
-    "Service.ConfigFile": "PublishPlotBot.json",
+    "Service.ConfigFile": "TestPlotBot.json",
     "Service.Interval": 1000,
     "Service.PlotBot.CleanupCache": true,
     "Service.PlotBot.CleanupFailedCopy":  true


### PR DESCRIPTION
Added 2 new drive clearers:
- OgByte: Checks the plot header bytes to determine if a plot is Og or Nft. Deletes Og plots to make room Nft plots. Doesn't require Chia to be installed.
- ZeroByte: Deletes plots that are 0 bytes in size. Hpool farmer creates these files when replotting. This drive clearer clears those for you.